### PR TITLE
Add pester blacklist config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.2.6
+- Added config option to blacklist enemies from being pestered.
 # 1.2.5
 - Fixed bug that caused the game to look slightly different with the mod on.
 # 1.2.4

--- a/LethalCompanyTemplate/Patches.cs
+++ b/LethalCompanyTemplate/Patches.cs
@@ -296,6 +296,9 @@ namespace Poltergeist
             if (__instance is DoublewingAI)
                 return;
 
+            if (Poltergeist.Config.IsEnemyPesterBlocked(__instance.GetType().Name))
+                return;
+
             //Everything else, set it up
             if (NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer)
             {

--- a/LethalCompanyTemplate/Poltergeist.cs
+++ b/LethalCompanyTemplate/Poltergeist.cs
@@ -13,7 +13,7 @@ namespace Poltergeist
         //Plugin info
         public const string MOD_GUID = "coderCleric.Poltergeist";
         public const string MOD_NAME = "Poltergeist";
-        public const string MOD_VERSION = "1.2.5";
+        public const string MOD_VERSION = "1.2.6";
 
         //Prefabs
         public static GameObject propInteractibleObject;

--- a/LethalCompanyTemplate/PoltergeistConfig.cs
+++ b/LethalCompanyTemplate/PoltergeistConfig.cs
@@ -23,6 +23,7 @@ namespace Poltergeist
         [field: SyncedEntryField] public SyncedEntry<float> TimeForAggro { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<int> HitsForAggro { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<float> AudioTime { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<string> PesterBlacklist { get; private set; }
 
         //Cost-related entries
         [field: SyncedEntryField] public SyncedEntry<float> DoorCost { get; private set; }
@@ -123,6 +124,14 @@ namespace Poltergeist
                     new AcceptableValueRange<float>(0, float.MaxValue)
                     )
                 );
+            PesterBlacklist = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced", "Pester blacklist"),
+                "",
+                new ConfigDescription(
+                    "Comma separated list of enemy script type names that cannot be pestered.",
+                    null
+                    )
+                );
 
             //Bind the cost-related configs
             DoorCost = cfg.BindSyncedEntry(
@@ -208,6 +217,20 @@ namespace Poltergeist
 
             //Register the config
             ConfigManager.Register(this);
+        }
+
+        public bool IsEnemyPesterBlocked(string typeName)
+        {
+            if (string.IsNullOrWhiteSpace(PesterBlacklist.Value))
+                return false;
+
+            string[] blocked = PesterBlacklist.Value.Split(',');
+            foreach (string s in blocked)
+            {
+                if (typeName.Equals(s.Trim(), StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These settings are synced, so whatever settings the host has will be used by eve
 - **Pester Aggro Timespan**: How many seconds have to pass before enemies forget that they've been pestered by any ghosts.
 - **Aggro Hit Requirement**: How many times do ghosts have to pester the same enemy before that enemy gets mad at the nearest player with line-of-sight.
 - **Audio Play Time**: How long ghost sounds can play, in seconds.
+- **Pester Blacklist**: Comma separated list of enemy script names that cannot be pestered.
 - **Costs**: Many different interaction costs are configurable, with the categories being:
   - **Regular Doors**
   - **Big Doors**: Both the pressurized facility doors as well as the Artifice hangar doors fall under this.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Poltergeist",
-  "version_number": "1.2.5",
+  "version_number": "1.2.6",
   "website_url": "https://github.com/coderCleric/Poltergeist",
   "description": "Lets players freecam on death as a ghost and do various interactions.",
   "dependencies": [ "BepInEx-BepInExPack-5.4.2100", "Rune580-LethalCompany_InputUtils-0.7.7", "Sigurd-CSync-5.0.1" ]

--- a/poltergeist_release/CHANGELOG.md
+++ b/poltergeist_release/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.2.6
+- Added config option to blacklist enemies from being pestered.
 # 1.2.5
 - Fixed bug that caused the game to look slightly different with the mod on.
 # 1.2.4

--- a/poltergeist_release/README.md
+++ b/poltergeist_release/README.md
@@ -71,6 +71,7 @@ These settings are synced, so whatever settings the host has will be used by eve
 - **Pester Aggro Timespan**: How many seconds have to pass before enemies forget that they've been pestered by any ghosts.
 - **Aggro Hit Requirement**: How many times do ghosts have to pester the same enemy before that enemy gets mad at the nearest player with line-of-sight.
 - **Audio Play Time**: How long ghost sounds can play, in seconds.
+- **Pester Blacklist**: Comma separated list of enemy script names that cannot be pestered.
 - **Costs**: Many different interaction costs are configurable, with the categories being:
   - **Regular Doors**
   - **Big Doors**: Both the pressurized facility doors as well as the Artifice hangar doors fall under this.

--- a/poltergeist_release/manifest.json
+++ b/poltergeist_release/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Poltergeist",
-  "version_number": "1.2.5",
+  "version_number": "1.2.6",
   "website_url": "https://github.com/coderCleric/Poltergeist",
   "description": "Lets players freecam on death as a ghost and do various interactions.",
   "dependencies": [ "BepInEx-BepInExPack-5.4.2100", "Rune580-LethalCompany_InputUtils-0.7.7", "Sigurd-CSync-5.0.1" ]


### PR DESCRIPTION
## Summary
- allow configuration for enemies that cannot be pestered
- bump version to 1.2.6
- document new option in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed7a679408333850bfcafa6da66b0