### PR TITLE
Fix pester blacklist check and add debug logging

### DIFF
--- a/LethalCompanyTemplate/Patches.cs
+++ b/LethalCompanyTemplate/Patches.cs
@@ -296,18 +296,35 @@ namespace Poltergeist
             if (__instance is DoublewingAI)
                 return;
 
-            if (Poltergeist.Config.IsEnemyPesterBlocked(__instance.GetType().Name))
-                return;
+            try
+            {
+                if (Poltergeist.Config.IsEnemyPesterBlocked(__instance.GetType().Name))
+                {
+                    Poltergeist.DebugLog($"Enemy {__instance.GetType().Name} is blacklisted from pestering");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Poltergeist.LogError($"Failed to check pester blacklist for {__instance.GetType().Name}: {ex}");
+            }
 
             //Everything else, set it up
             if (NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer)
             {
-                Poltergeist.DebugLog("Making interactor for " + __instance.name);
-                GameObject interactObject = GameObject.Instantiate(Poltergeist.enemyInteractibleObject, __instance.transform);
-                interactObject.name = __instance.name + "Interactor";
-                interactObject.GetComponent<NetworkedInteractible>().intendedParent = __instance.transform;
-                interactObject.GetComponent<NetworkObject>().Spawn();
-                interactObject.transform.parent = __instance.transform;
+                try
+                {
+                    Poltergeist.DebugLog("Making interactor for " + __instance.name);
+                    GameObject interactObject = GameObject.Instantiate(Poltergeist.enemyInteractibleObject, __instance.transform);
+                    interactObject.name = __instance.name + "Interactor";
+                    interactObject.GetComponent<NetworkedInteractible>().intendedParent = __instance.transform;
+                    interactObject.GetComponent<NetworkObject>().Spawn();
+                    interactObject.transform.parent = __instance.transform;
+                }
+                catch (Exception ex)
+                {
+                    Poltergeist.LogError($"Failed to add enemy interactor for {__instance.name}: {ex}");
+                }
             }
         }
 

--- a/LethalCompanyTemplate/PoltergeistConfig.cs
+++ b/LethalCompanyTemplate/PoltergeistConfig.cs
@@ -132,6 +132,7 @@ namespace Poltergeist
                     null
                     )
                 );
+            Poltergeist.DebugLog($"Loaded pester blacklist: '{PesterBlacklist.Value}'");
 
             //Bind the cost-related configs
             DoorCost = cfg.BindSyncedEntry(
@@ -221,14 +222,31 @@ namespace Poltergeist
 
         public bool IsEnemyPesterBlocked(string typeName)
         {
-            if (string.IsNullOrWhiteSpace(PesterBlacklist.Value))
-                return false;
-
-            string[] blocked = PesterBlacklist.Value.Split(',');
-            foreach (string s in blocked)
+            try
             {
-                if (typeName.Equals(s.Trim(), StringComparison.OrdinalIgnoreCase))
-                    return true;
+                if (string.IsNullOrWhiteSpace(PesterBlacklist.Value))
+                    return false;
+
+                string[] blocked = PesterBlacklist.Value.Split(',');
+                foreach (string s in blocked)
+                {
+                    string trimmed = s.Trim();
+                    if (string.IsNullOrEmpty(trimmed))
+                        continue;
+
+                    bool match = typeName.Equals(trimmed, StringComparison.OrdinalIgnoreCase) ||
+                                 typeName.EndsWith(trimmed, StringComparison.OrdinalIgnoreCase);
+
+                    if (match)
+                    {
+                        Poltergeist.DebugLog($"Blacklisted enemy type matched: {typeName} matches {trimmed}");
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Poltergeist.LogError($"Error checking pester blacklist for {typeName}: {ex}");
             }
             return false;
         }


### PR DESCRIPTION
## Summary
- log blacklist value on startup
- fix enemy blacklist comparison and log when matches occur
- log when enemy interactor creation is skipped or fails
- handle errors when applying blacklist or creating interactors

## Testing
- `dotnet build LethalCompanyTemplate/Poltergeist.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee4c41ffc83339de81daaeedcf0bb