### PR TITLE
Add global feature toggles

### DIFF
--- a/LethalCompanyTemplate/GhostHead.cs
+++ b/LethalCompanyTemplate/GhostHead.cs
@@ -197,7 +197,8 @@ namespace Poltergeist
         [ClientRpc]
         public void ManifestClientRpc()
         {
-            PlayFlickerAnim();
+            if (Poltergeist.Config.EnableManifest.Value)
+                PlayFlickerAnim();
         }
 
         /**
@@ -244,7 +245,8 @@ namespace Poltergeist
         [ClientRpc]
         public void BarkClientRpc(int index)
         {
-            PlayBarkAudio(index);
+            if (Poltergeist.Config.EnableAudio.Value)
+                PlayBarkAudio(index);
         }
 
         /**
@@ -269,6 +271,9 @@ namespace Poltergeist
          */
         public void PlayBarkAudio(int index)
         {
+            if (!Poltergeist.Config.EnableAudio.Value)
+                return;
+
             //Make sure it's not already playing
             if (IsBarking())
                 return;

--- a/LethalCompanyTemplate/GhostInteractibles/Specific/BasicInteractible.cs
+++ b/LethalCompanyTemplate/GhostInteractibles/Specific/BasicInteractible.cs
@@ -45,11 +45,34 @@ namespace Poltergeist.GhostInteractibles.Specific
             }
         }
 
+        private bool FeatureEnabled()
+        {
+            switch(costType)
+            {
+                case CostType.DOOR:
+                    return Poltergeist.Config.EnableDoor.Value;
+                case CostType.VALVE:
+                    return Poltergeist.Config.EnableValve.Value;
+                case CostType.SHIPDOOR:
+                    return Poltergeist.Config.EnableShipDoor.Value;
+                case CostType.COMPANYBELL:
+                    return Poltergeist.Config.EnableCompanyBell.Value;
+                case CostType.HANGARDOOR:
+                    return Poltergeist.Config.EnableBigDoor.Value;
+                default:
+                    return Poltergeist.Config.EnableMisc.Value;
+            }
+        }
+
         /**
          * Do the actual interaction
          */
         public override float Interact(Transform playerTransform)
         {
+            //Check if this feature is enabled
+            if (!FeatureEnabled())
+                return 0;
+
             //Don't let them interact without meeting the cost
             if (SpectatorCamController.instance.Power < GetCost())
                 return 0;
@@ -75,6 +98,10 @@ namespace Poltergeist.GhostInteractibles.Specific
          */
         public override string GetTipText()
         {
+            //Don't show anything if disabled
+            if (!FeatureEnabled())
+                return "";
+
             string retStr = "";
 
             //Display message for not having enough power

--- a/LethalCompanyTemplate/GhostInteractibles/Specific/BigDoorInteractible.cs
+++ b/LethalCompanyTemplate/GhostInteractibles/Specific/BigDoorInteractible.cs
@@ -35,6 +35,9 @@ namespace Poltergeist.GhostInteractibles.Specific
          */
         public override float Interact(Transform playerTransform)
         {
+            if (!Poltergeist.Config.EnableBigDoor.Value)
+                return 0;
+
             //Don't let them interact without meeting the cost
             if (SpectatorCamController.instance.Power < GetCost())
                 return 0;
@@ -56,6 +59,9 @@ namespace Poltergeist.GhostInteractibles.Specific
          */
         public override string GetTipText()
         {
+            if (!Poltergeist.Config.EnableBigDoor.Value)
+                return "";
+
             string retStr = "";
 
             //Display message for not having enough power

--- a/LethalCompanyTemplate/GhostInteractibles/Specific/EnemyInteractible.cs
+++ b/LethalCompanyTemplate/GhostInteractibles/Specific/EnemyInteractible.cs
@@ -61,6 +61,9 @@ namespace Poltergeist.GhostInteractibles.Specific
          */
         public override float Interact(Transform playerTransform)
         {
+            if (!Poltergeist.Config.EnablePester.Value)
+                return 0;
+
             //Abort if there's no enemy somehow
             if (enemy == null)
                 return 0;
@@ -114,6 +117,9 @@ namespace Poltergeist.GhostInteractibles.Specific
          */
         public override string GetTipText()
         {
+            if (!Poltergeist.Config.EnablePester.Value)
+                return "";
+
             //Abort if there's no enemy somehow
             if (enemy == null)
                 return "Enemy is not synced!";

--- a/LethalCompanyTemplate/GhostInteractibles/Specific/PropInteractible.cs
+++ b/LethalCompanyTemplate/GhostInteractibles/Specific/PropInteractible.cs
@@ -45,6 +45,9 @@ namespace Poltergeist.GhostInteractibles.Specific
          */
         public override float Interact(Transform playerTransform)
         {
+            if (!Poltergeist.Config.EnableNoisyItem.Value)
+                return 0;
+
             //Abort if there's no prop somehow
             if (prop == null)
                 return 0;
@@ -83,6 +86,9 @@ namespace Poltergeist.GhostInteractibles.Specific
          */
         public override string GetTipText()
         {
+            if (!Poltergeist.Config.EnableNoisyItem.Value)
+                return "";
+
             //Abort if there's no prop somehow
             if (prop == null)
                 return "Prop not synced correctly!";

--- a/LethalCompanyTemplate/Patches.cs
+++ b/LethalCompanyTemplate/Patches.cs
@@ -150,14 +150,15 @@ namespace Poltergeist
         public static void AddGhostInteractor(InteractTrigger __instance)
         {
             //If it's a door, add the interactible
-            if (__instance.gameObject.GetComponent<DoorLock>() != null) {
+            if (__instance.gameObject.GetComponent<DoorLock>() != null && Poltergeist.Config.EnableDoor.Value) {
                 BasicInteractible interactible = __instance.gameObject.AddComponent<BasicInteractible>();
                 interactible.costType = CostType.DOOR;
                 return;
             }
 
             //If its a lightswitch or a storage locker, add one
-            if (__instance.name.Equals("LightSwitch") || (__instance.transform.parent != null && __instance.transform.parent.name.Contains("storage")))
+            if ((__instance.name.Equals("LightSwitch") || (__instance.transform.parent != null && __instance.transform.parent.name.Contains("storage")))
+                && Poltergeist.Config.EnableMisc.Value)
             {
                 BasicInteractible interactible = __instance.gameObject.AddComponent<BasicInteractible>();
                 return;
@@ -165,7 +166,7 @@ namespace Poltergeist
 
             //If it's a ship decoration, add it (can't figure out a better way than checking name)
             Transform parent = __instance.transform.parent;
-            if(parent != null)
+            if(parent != null && Poltergeist.Config.EnableMisc.Value)
             {
                 if(parent.name.Contains("Pumpkin") || parent.name.Contains("Television") || parent.name.Contains("Record") || parent.name.Contains("Romantic")
                      || parent.name.Contains("Shower") || parent.name.Contains("Toilet") || parent.name.Contains("Plushie"))
@@ -176,7 +177,7 @@ namespace Poltergeist
             }
 
             //If it's one of the ship buttons, add one
-            if(parent != null)
+            if(parent != null && Poltergeist.Config.EnableShipDoor.Value)
             {
                 if(parent.name.Equals("StartButton") || parent.name.Equals("StopButton"))
                 {
@@ -187,7 +188,7 @@ namespace Poltergeist
             }
 
             //If it's a steam valve, add one
-            if(__instance.gameObject.GetComponent<SteamValveHazard>() != null)
+            if(__instance.gameObject.GetComponent<SteamValveHazard>() != null && Poltergeist.Config.EnableValve.Value)
             {
                 BasicInteractible interactible = __instance.gameObject.AddComponent<BasicInteractible>();
                 interactible.costType = CostType.VALVE;
@@ -195,7 +196,7 @@ namespace Poltergeist
             }
 
             //If it's the company bell, add one
-            if (parent != null)
+            if (parent != null && Poltergeist.Config.EnableCompanyBell.Value)
             {
                 if (parent.name.Equals("BellDinger"))
                 {
@@ -206,7 +207,7 @@ namespace Poltergeist
             }
 
             //If it's the lever for the big hangar, add one
-            if(__instance.name.Contains("LeverSwitchHandle"))
+            if(__instance.name.Contains("LeverSwitchHandle") && Poltergeist.Config.EnableBigDoor.Value)
             {
                 BasicInteractible interactible = __instance.gameObject.AddComponent<BasicInteractible>();
                 interactible.costType = CostType.HANGARDOOR;
@@ -214,7 +215,7 @@ namespace Poltergeist
             }
 
             //If it's the loudhorn, add one
-            if(__instance.GetComponent<ShipAlarmCord>() != null)
+            if(__instance.GetComponent<ShipAlarmCord>() != null && Poltergeist.Config.EnableMisc.Value)
             {
                 BasicInteractible interactible = __instance.gameObject.AddComponent<BasicInteractible>();
                 interactible.costType = CostType.MISC;
@@ -223,7 +224,7 @@ namespace Poltergeist
             }
 
             //If it's the elevator button, add one
-            if (__instance.transform.parent != null && __instance.transform.parent.name.Equals("ElevatorButtonTrigger"))
+            if (__instance.transform.parent != null && __instance.transform.parent.name.Equals("ElevatorButtonTrigger") && Poltergeist.Config.EnableBigDoor.Value)
             {
                 BasicInteractible interactible = __instance.gameObject.AddComponent<BasicInteractible>();
                 interactible.costType = CostType.HANGARDOOR;
@@ -240,7 +241,7 @@ namespace Poltergeist
         [HarmonyPatch(typeof(GrabbableObject), "Start")]
         public static void AddInteractorForProp(GrabbableObject __instance)
         {
-            if (NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer)
+            if ((NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer) && Poltergeist.Config.EnableNoisyItem.Value)
             {
                 if (__instance is NoisemakerProp || __instance is BoomboxItem ||
                     __instance is RadarBoosterItem || __instance is RemoteProp) {
@@ -263,7 +264,7 @@ namespace Poltergeist
         public static void AddInteractorForBigDoors(TerminalAccessibleObject __instance)
         {
             //Only add if it's a big door
-            if(__instance.name.Contains("BigDoor"))
+            if(__instance.name.Contains("BigDoor") && Poltergeist.Config.EnableBigDoor.Value)
             {
                 //Make the gameobject on the door
                 GameObject interactObj = new GameObject();
@@ -292,6 +293,9 @@ namespace Poltergeist
         [HarmonyPatch(typeof(MaskedPlayerEnemy), "Start")]
         public static void AddInteractorForEnemies(EnemyAI __instance)
         {
+            if (!Poltergeist.Config.EnablePester.Value)
+                return;
+
             //Screw manticoils all my homies hate manticoils
             if (__instance is DoublewingAI)
                 return;
@@ -310,7 +314,7 @@ namespace Poltergeist
             }
 
             //Everything else, set it up
-            if (NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer)
+            if ((NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer) && Poltergeist.Config.EnablePester.Value)
             {
                 try
                 {
@@ -336,7 +340,7 @@ namespace Poltergeist
         public static void WhoopiePatch(GrabbableObject __instance)
         {
             //See if this is a whoopie cushion, and make the ghost trigger if it is
-            if (__instance is WhoopieCushionItem)
+            if (Poltergeist.Config.EnableNoisyItem.Value && __instance is WhoopieCushionItem)
             {
                 GameObject.Instantiate(Poltergeist.itemTriggerObject, __instance.transform).transform.localPosition = Vector3.zero;
             }

--- a/LethalCompanyTemplate/PoltergeistConfig.cs
+++ b/LethalCompanyTemplate/PoltergeistConfig.cs
@@ -37,6 +37,18 @@ namespace Poltergeist
         [field: SyncedEntryField] public SyncedEntry<float> BarkCost { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<float> MiscCost { get; private set; }
 
+        //Feature toggle entries
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableDoor { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableBigDoor { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableNoisyItem { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableValve { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableShipDoor { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableCompanyBell { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnablePester { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableManifest { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableAudio { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> EnableMisc { get; private set; }
+
         /**
          * Make an instance of the config
          */
@@ -213,6 +225,88 @@ namespace Poltergeist
                 new ConfigDescription(
                     "The power required to do any interactions not covered by another section.",
                     new AcceptableValueRange<float>(0, float.MaxValue)
+                    )
+                );
+
+            //Bind the feature toggles
+            EnableDoor = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable door"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot open or close regular doors.",
+                    null
+                    )
+                );
+            EnableBigDoor = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable big door"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot interact with large doors or the mineshaft elevator.",
+                    null
+                    )
+                );
+            EnableNoisyItem = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable noisy item"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot use noisy items or whoopie cushions.",
+                    null
+                    )
+                );
+            EnableValve = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable valve"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot turn steam valves.",
+                    null
+                    )
+                );
+            EnableShipDoor = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable ship door"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot use ship doors.",
+                    null
+                    )
+                );
+            EnableCompanyBell = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable company bell"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot ring the company bell.",
+                    null
+                    )
+                );
+            EnablePester = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable pester"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot pester enemies.",
+                    null
+                    )
+                );
+            EnableManifest = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable manifest"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot manifest.",
+                    null
+                    )
+                );
+            EnableAudio = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable audio"),
+                true,
+                new ConfigDescription(
+                    "If false, ghosts cannot play audio.",
+                    null
+                    )
+                );
+            EnableMisc = cfg.BindSyncedEntry(
+                new ConfigDefinition("Synced: Features", "Enable misc"),
+                true,
+                new ConfigDescription(
+                    "If false, miscellaneous ghost interactions are disabled.",
+                    null
                     )
                 );
 

--- a/LethalCompanyTemplate/SpectatorCamController.cs
+++ b/LethalCompanyTemplate/SpectatorCamController.cs
@@ -232,10 +232,12 @@ namespace Poltergeist
                 str += "Lock Altitude; [" + PoltergeistCustomInputs.GetKeyString(PoltergeistCustomInputs.instance.LockKey) + "]\n\n";
                 str += "Teleport to players; [1-9]\n";
                 str += "Toggle Ghost Light; [" + PoltergeistCustomInputs.GetKeyString(PoltergeistCustomInputs.instance.SwitchLightButton) + "]\n";
-                str += "Manifest; [" + PoltergeistCustomInputs.GetKeyString(PoltergeistCustomInputs.instance.ManifestKey) + "] (Cost: "
-                    + Poltergeist.Config.ManifestCost.Value + ")\n";
-                str += "Play Audio; [" + PoltergeistCustomInputs.GetKeyString(PoltergeistCustomInputs.instance.BarkKey) + "] (Cost: "
-                    + Poltergeist.Config.BarkCost.Value + ")";
+                if (Poltergeist.Config.EnableManifest.Value)
+                    str += "Manifest; [" + PoltergeistCustomInputs.GetKeyString(PoltergeistCustomInputs.instance.ManifestKey) + "] (Cost: "
+                        + Poltergeist.Config.ManifestCost.Value + ")\n";
+                if (Poltergeist.Config.EnableAudio.Value)
+                    str += "Play Audio; [" + PoltergeistCustomInputs.GetKeyString(PoltergeistCustomInputs.instance.BarkKey) + "] (Cost: "
+                        + Poltergeist.Config.BarkCost.Value + ")";
             }
             controlsText.text = str;
         }
@@ -436,6 +438,9 @@ namespace Poltergeist
             if (!context.performed || Patches.vanillaMode)
                 return;
 
+            if (!Poltergeist.Config.EnableManifest.Value)
+                return;
+
             //Don't do things if paused
             if (clientPlayer.isTypingChat || clientPlayer.quickMenuManager.isMenuOpen)
                 return;
@@ -455,6 +460,9 @@ namespace Poltergeist
         {
             //Only do it if performing and not in vanilla mode
             if (!context.performed || Patches.vanillaMode)
+                return;
+
+            if (!Poltergeist.Config.EnableAudio.Value)
                 return;
             
             //Don't do things if paused
@@ -498,8 +506,10 @@ namespace Poltergeist
             PoltergeistCustomInputs.instance.DecelerateButton.performed += Decelerate;
             PoltergeistCustomInputs.instance.ToggleButton.performed += SwitchModes;
             PoltergeistCustomInputs.instance.LockKey.performed += LockAltitude;
-            PoltergeistCustomInputs.instance.ManifestKey.performed += ManifestHead;
-            PoltergeistCustomInputs.instance.BarkKey.performed += Bark;
+            if (Poltergeist.Config.EnableManifest.Value)
+                PoltergeistCustomInputs.instance.ManifestKey.performed += ManifestHead;
+            if (Poltergeist.Config.EnableAudio.Value)
+                PoltergeistCustomInputs.instance.BarkKey.performed += Bark;
             PoltergeistCustomInputs.instance.ToggleControlsKey.performed += ToggleControlVis;
 
         }
@@ -511,8 +521,10 @@ namespace Poltergeist
             PoltergeistCustomInputs.instance.DecelerateButton.performed -= Decelerate;
             PoltergeistCustomInputs.instance.ToggleButton.performed -= SwitchModes;
             PoltergeistCustomInputs.instance.LockKey.performed -= LockAltitude;
-            PoltergeistCustomInputs.instance.ManifestKey.performed -= ManifestHead;
-            PoltergeistCustomInputs.instance.BarkKey.performed -= Bark;
+            if (Poltergeist.Config.EnableManifest.Value)
+                PoltergeistCustomInputs.instance.ManifestKey.performed -= ManifestHead;
+            if (Poltergeist.Config.EnableAudio.Value)
+                PoltergeistCustomInputs.instance.BarkKey.performed -= Bark;
             PoltergeistCustomInputs.instance.ToggleControlsKey.performed -= ToggleControlVis;
         }
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ These settings are synced, so whatever settings the host has will be used by eve
 - **Aggro Hit Requirement**: How many times do ghosts have to pester the same enemy before that enemy gets mad at the nearest player with line-of-sight.
 - **Audio Play Time**: How long ghost sounds can play, in seconds.
 - **Pester Blacklist**: Comma separated list of enemy script names that cannot be pestered.
+- **Feature Toggles**: Each interaction type can be disabled entirely. Toggles exist for:
+  - **Regular Doors**
+  - **Big Doors**
+  - **Noisy Items**
+  - **Steam Valves**
+  - **Ship Doors**
+  - **The Company Bell**
+  - **Enemy Pestering**
+  - **Manifest**
+  - **Playing Audio**
+  - **Miscellaneous**
 - **Costs**: Many different interaction costs are configurable, with the categories being:
   - **Regular Doors**
   - **Big Doors**: Both the pressurized facility doors as well as the Artifice hangar doors fall under this.

--- a/poltergeist_release/README.md
+++ b/poltergeist_release/README.md
@@ -72,6 +72,17 @@ These settings are synced, so whatever settings the host has will be used by eve
 - **Aggro Hit Requirement**: How many times do ghosts have to pester the same enemy before that enemy gets mad at the nearest player with line-of-sight.
 - **Audio Play Time**: How long ghost sounds can play, in seconds.
 - **Pester Blacklist**: Comma separated list of enemy script names that cannot be pestered.
+- **Feature Toggles**: Each interaction type can be disabled entirely. Toggles exist for:
+  - **Regular Doors**
+  - **Big Doors**
+  - **Noisy Items**
+  - **Steam Valves**
+  - **Ship Doors**
+  - **The Company Bell**
+  - **Enemy Pestering**
+  - **Manifest**
+  - **Playing Audio**
+  - **Miscellaneous**
 - **Costs**: Many different interaction costs are configurable, with the categories being:
   - **Regular Doors**
   - **Big Doors**: Both the pressurized facility doors as well as the Artifice hangar doors fall under this.


### PR DESCRIPTION
## Summary
- introduce synced config booleans for each interaction type
- skip adding interactibles when a feature is disabled
- check feature settings inside all interactibles
- gate manifest and audio behaviour by feature flags
- document feature toggles in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804ec897c08333a782b5b6591c961b